### PR TITLE
Add LandMark & Adjust Player buyCard (LandMark)

### DIFF
--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -34,6 +34,8 @@ public class Game {
         this.turnPlayer = turnPlayer;
     }
 
+    public boolean isTurnPlayer(Player player) {return this.getTurnPlayer().equals(player);}
+
     public void setCurrentDicePoint(int currentDicePoint) {
         this.currentDicePoint = currentDicePoint;
     }

--- a/src/main/java/domain/Player.java
+++ b/src/main/java/domain/Player.java
@@ -1,16 +1,17 @@
 package domain;
 
 import domain.card.establishment.Establishment;
-import domain.card.landmark.Landmark;
+import domain.card.landmark.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Player {
     private final String name;
     private int totalCoin = 3;
     private List<Establishment> ownedEstablishment = new ArrayList<>();
-    private List<Landmark> ownedLandmark = new ArrayList<>();
+    private List<Landmark> ownedLandmark = new ArrayList<>(Arrays.asList(new TrainStation(),new ShoppingMall(),new AmusementPark(),new RadioTower())); //FIXME: Do we need to initialize?
 
     public Player(String name) {
         this.name = name;
@@ -37,21 +38,24 @@ public class Player {
         if (!isBalanceEnough(cost))
             return; // FIXME: 2022/12/8 throw Exception or other way to handle this condition.
 
-        totalCoin -= cost; // FIXME: 2022/12/8 need to refactor after payCoin implemented.
-        getOwnedEstablishment().add(card);
+        this.payCoin(cost);
+        addCardToHandCard(card);
     }
 
-    public void buyCard(Landmark card) {
+    public void flipLandMark(Landmark card) {
         int cost = card.getConstructionCost();
         if (!isBalanceEnough(cost))
             return; // FIXME: 2022/12/8 throw Exception or other way to handle this condition.
 
-        totalCoin -= cost; // FIXME: 2022/12/8 need to refactor after payCoin implemented.
-        getOwnedLandmark().add(card);
+        this.payCoin(cost);
+        getOwnedLandmark().stream()
+                .filter(landmark -> landmark.equals(card))
+                .forEach(landmark -> landmark.setCardSide(Landmark.CardSide.FRONT));
+
     }
 
     public void payCoin(int coin) {
-       this.totalCoin -= coin;
+        this.totalCoin -= coin;
     }
 
     public void gainCoin(int coin) {

--- a/src/main/java/domain/card/establishment/Cafe.java
+++ b/src/main/java/domain/card/establishment/Cafe.java
@@ -15,7 +15,7 @@ public class Cafe extends Establishment {
     @Override
     public void takeEffect(Game game, Player player) {
         // 如果別人骰出這個數字，他必須給你1元
-        if (isDicePointToTakeEffect(game.getCurrentDicePoint()) && playerHasEnoughCoin(game)) {
+        if (!game.isTurnPlayer(player) && isDicePointToTakeEffect(game.getCurrentDicePoint()) && playerHasEnoughCoin(game)) {
             game.getTurnPlayer().payCoin(COIN_TO_PAY);
             player.gainCoin(COIN_TO_GAIN);
         }

--- a/src/main/java/domain/card/landmark/Landmark.java
+++ b/src/main/java/domain/card/landmark/Landmark.java
@@ -16,10 +16,16 @@ public class Landmark extends Card {
 
     public void takeEffect(Game game, Player player) {
 
-
     }
-
     public enum CardSide {
         FRONT, BACK
+    }
+
+    public CardSide getCardSide() {
+        return cardSide;
+    }
+
+    public void setCardSide(CardSide cardSide) {
+        this.cardSide = cardSide;
     }
 }

--- a/src/main/java/domain/card/landmark/RadioTower.java
+++ b/src/main/java/domain/card/landmark/RadioTower.java
@@ -1,0 +1,9 @@
+package domain.card.landmark;
+
+import domain.card.CardType;
+
+public class RadioTower extends Landmark {
+    public RadioTower() {
+        super("廣播電台", 22, CardType.MAJOR_ESTABLISHMENT);
+    }
+}

--- a/src/main/java/domain/card/landmark/ShoppingMall.java
+++ b/src/main/java/domain/card/landmark/ShoppingMall.java
@@ -1,0 +1,9 @@
+package domain.card.landmark;
+
+import domain.card.CardType;
+
+public class ShoppingMall extends Landmark{
+    public ShoppingMall() {
+        super("購物中心", 10, CardType.MAJOR_ESTABLISHMENT);
+    }
+}

--- a/src/main/java/domain/card/landmark/TrainStation.java
+++ b/src/main/java/domain/card/landmark/TrainStation.java
@@ -1,0 +1,10 @@
+package domain.card.landmark;
+
+import domain.card.CardType;
+
+public class TrainStation extends Landmark{
+
+    public TrainStation() {
+        super("火車站", 4, CardType.MAJOR_ESTABLISHMENT);
+    }
+}

--- a/src/test/java/domain/PlayerTest.java
+++ b/src/test/java/domain/PlayerTest.java
@@ -1,8 +1,8 @@
 package domain;
 
 import domain.card.landmark.AmusementPark;
-import domain.Player;
 import domain.card.establishment.WheatField;
+import domain.card.landmark.Landmark;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,23 +14,35 @@ class PlayerTest {
 
     @BeforeEach
     void setUp() {
-        player = new Player("m1wt9ILw") {
-            @Override
-            public int getTotalCoin() {
-                return 1000;
-            }
-        };
+        player = new Player("m1wt9ILw");
+        player.gainCoin(97);
     }
 
     @Test
     void buyCard() {
+        //given
+        var originalBalanceOfPlayer = player.getTotalCoin();
         var card = new WheatField();
+
+        //when
         player.buyCard(card);
+
+        //then
+        assertThat(player.getTotalCoin()).isEqualTo(originalBalanceOfPlayer - 1);
         assertThat(player.getOwnedEstablishment().get(0)).isEqualTo(card);
+    }
 
+    @Test
+    void flipLandMark() {
+        //given
+        var originalBalanceOfPlayer = player.getTotalCoin();
         var landMark = new AmusementPark();
-        player.buyCard(landMark);
-        assertThat(player.getOwnedLandmark().get(0)).isEqualTo(landMark);
 
+        //when
+        player.flipLandMark(landMark);
+
+        //then
+        assertThat(player.getTotalCoin()).isEqualTo(originalBalanceOfPlayer - 16);
+        assertThat(player.getOwnedLandmark().get(2).getCardSide()).isEqualTo(Landmark.CardSide.FRONT);
     }
 }

--- a/src/test/java/domain/card/establishment/CafeTest.java
+++ b/src/test/java/domain/card/establishment/CafeTest.java
@@ -32,15 +32,22 @@ class CafeTest {
 
     @Test
     void testTakeEffect() {
-        game = new Game(new Bank(100), List.of(playerA,playerB), null, null);
-        playerB.addCardToHandCard(cafe);
+        //given
+        game = new Game(new Bank(100), List.of(playerA, playerB), null, null) {
+            @Override
+            public int getCurrentDicePoint() {
+                return 3;
+            }
+        };
+        int original_playerA_totalCoin = playerA.getTotalCoin();
+        int original_playerB_totalCoin = playerB.getTotalCoin();
 
+        //when
         game.setTurnPlayer(playerA);
+        cafe.takeEffect(game, playerB);
 
-        game.setCurrentDicePoint(3);
-        cafe.takeEffect(game,playerB);
-
-        assertEquals(2,playerA.getTotalCoin());
-        assertEquals(4,playerB.getTotalCoin());
+        //then
+        assertEquals(original_playerA_totalCoin - 1, playerA.getTotalCoin());
+        assertEquals(original_playerB_totalCoin + 1, playerB.getTotalCoin());
     }
 }


### PR DESCRIPTION
https://github.com/Game-as-a-Service/Machi-Koro-Java/issues/40
主要新增&修改：

- 初始化Player裡的ownedLandmark，讓玩家一開始就擁有四個地標(背面)。
- 將 原本Player裡的buyCard(Landmark card)裡的邏輯修改，並重新命名為 flipLandMark()。
- 新增 其他三個地標至 landmark package底下，只有初始化建構子而已。
- 修改原本PlayerTest，將購買建築物與翻地標卡拆為兩個測項，並新增Player購買完成後金額的測試。
- Game裡加入isTurnPlayer()，讓Game類別判斷是否為當前玩家(12/11開會討論)。